### PR TITLE
Add beMissing generator to replace beNull generator that uses depreca…

### DIFF
--- a/lib/generators/filterGenerator.js
+++ b/lib/generators/filterGenerator.js
@@ -93,6 +93,9 @@ FilterGenerator.prototype.beInRange = function(min, max) {
     return this.cb(term);
 };
 
+/***
+ * OBSOLETE
+ */
 FilterGenerator.prototype.beNull = function() {
     var field = this.field;
     var term = {

--- a/lib/generators/queryGenerator.js
+++ b/lib/generators/queryGenerator.js
@@ -25,4 +25,17 @@ QueryGenerator.prototype.startsWith = function(q) {
     return this.cb(query);
 };
 
+QueryGenerator.prototype.beMissing = function() {
+    var field = this.field;
+    var query = {
+        bool: {
+            must_not: {
+                exists: {
+                    field: field
+                }
+            }
+        }
+    };
 
+    return this.cb(query);
+};

--- a/test/queryGenerator.js
+++ b/test/queryGenerator.js
@@ -20,4 +20,23 @@ describe('QueryGenerator', function () {
             }, ['field1', 'field2']).startsWith('test');
         });
     });
+
+    describe('#beMissing', function () {
+        it('should produce a must not exists query on the passed in fields', function (done) {
+            var expected = {
+                bool: {
+                    must_not: {
+                        exists: {
+                            field: ['field1', 'field2']
+                        }
+                    }
+                }
+            };
+
+            new QueryGenerator(function (actual) {
+                actual.should.eql(expected);
+                done();
+            }, ['field1', 'field2']).beMissing();
+        });
+    });
 });


### PR DESCRIPTION
beNull uses a missing query, which is deprecated after ES 2.2.0: 

https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl-missing-query.html

This change will add a new generator called beMissing that achieves the same functionality, and the beNull should be removed at a later date.